### PR TITLE
add aws_ami variable to the modules for instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,7 @@ module "dcos-bootstrap-instance" {
   aws_key_name           = "${var.ssh_public_key == "none" ? var.aws_key_name : element(coalescelist(aws_key_pair.deployer.*.key_name, list("")), 0)}"
 
   dcos_instance_os                = "${coalesce(var.bootstrap_os,var.dcos_instance_os)}"
+  aws_ami                         = "${var.aws_ami}"
   aws_root_volume_size            = "${var.bootstrap_root_volume_size}"
   aws_root_volume_type            = "${var.bootstrap_root_volume_type}"
   aws_instance_type               = "${var.bootstrap_instance_type}"
@@ -136,6 +137,7 @@ module "dcos-master-instances" {
   num_masters = "${var.num_masters}"
 
   dcos_instance_os                = "${coalesce(var.masters_os,var.dcos_instance_os)}"
+  aws_ami                         = "${var.aws_ami}"
   aws_root_volume_size            = "${var.masters_root_volume_size}"
   aws_instance_type               = "${var.masters_instance_type}"
   aws_associate_public_ip_address = "${var.masters_associate_public_ip_address}"
@@ -160,6 +162,7 @@ module "dcos-privateagent-instances" {
   num_private_agents = "${var.num_private_agents}"
 
   dcos_instance_os                = "${coalesce(var.private_agents_os,var.dcos_instance_os)}"
+  aws_ami                         = "${var.aws_ami}"
   aws_root_volume_size            = "${var.private_agents_root_volume_size}"
   aws_root_volume_type            = "${var.private_agents_root_volume_type}"
   aws_instance_type               = "${var.private_agents_instance_type}"
@@ -187,6 +190,7 @@ module "dcos-publicagent-instances" {
   num_public_agents = "${var.num_public_agents}"
 
   dcos_instance_os                = "${coalesce(var.public_agents_os,var.dcos_instance_os)}"
+  aws_ami                         = "${var.aws_ami}"
   aws_root_volume_size            = "${var.public_agents_root_volume_size}"
   aws_root_volume_type            = "${var.public_agents_root_volume_type}"
   aws_instance_type               = "${var.public_agents_instance_type}"


### PR DESCRIPTION
Currently, within this module, if you specify the "aws_ami" as a variable it will not get passed to any of the lower submodules modules and it will not use the desired AMI but use the default from tested-os. We need to add this variable here for users that would like to use a custom AMI vs the default that we supply. 

This variable is also supplied as an option in the outter module terraform-aws-dcos (wrapper script). If it is not supplied here, it will get dropped and will not be passed to the lower modules for the instances. 