### PR TITLE
Dynamic Masters POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EXAMPLE
 ```hcl
 module "dcos-master-instances" {
   source  = "terraform-dcos/masters/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
   ssh_public_key = "ssh-rsa ..."
@@ -43,6 +43,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | availability_zones | Availability zones to be used | list | `<list>` | no |
 | aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
 | aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key_file to empty string | string | `` | no |
+| aws_s3_bucket | S3 Bucket for External Exhibitor | string | `` | no |
 | bootstrap_associate_public_ip_address | [BOOTSTRAP] Associate a public ip address with there instances | string | `true` | no |
 | bootstrap_aws_ami | [BOOTSTRAP] AMI to be used | string | `` | no |
 | bootstrap_iam_instance_profile | [BOOTSTRAP] Instance profile to be used for these instances | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -86,8 +86,7 @@ module "dcos-security-groups" {
 
 // Permissions creates instances profiles so you could use Rexray and Kubernetes with AWS support
 module "dcos-iam" {
-  #source  = "dcos-terraform/iam/aws"
-  source  = "git::https://github.com/dcos-terraform/terraform-aws-iam?ref=dynam-masters-poc"
+  source  = "dcos-terraform/iam/aws"
   version = "~> 0.1.0"
 
   providers = {

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "dcos-master-instances" {
  *   source  = "terraform-dcos/masters/aws"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  *   ssh_public_key = "ssh-rsa ..."
@@ -56,7 +56,7 @@ resource "aws_key_pair" "deployer" {
 // Create a VPC and subnets
 module "dcos-vpc" {
   source  = "dcos-terraform/vpc/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # version = "0.0.1"
   providers = {
@@ -86,19 +86,30 @@ module "dcos-security-groups" {
 
 // Permissions creates instances profiles so you could use Rexray and Kubernetes with AWS support
 module "dcos-iam" {
-  source  = "dcos-terraform/iam/aws"
-  version = "~> 0.1"
+  #source  = "dcos-terraform/iam/aws"
+  source  = "git::https://github.com/dcos-terraform/terraform-aws-iam?ref=dynam-masters-poc"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
   }
 
-  cluster_name = "${var.cluster_name}"
+  cluster_name  = "${var.cluster_name}"
+  aws_s3_bucket = "${var.aws_s3_bucket}"
+}
+
+// If External Exhibitor is Specified, Create the Bucket
+resource "aws_s3_bucket" "external_exhibitor" {
+  count  = "${var.aws_s3_bucket != "" ? 1 : 0}"
+  bucket = "${var.aws_s3_bucket}"
+  acl    = "private"
+
+  tags = "${var.tags}"
 }
 
 module "dcos-bootstrap-instance" {
   source  = "dcos-terraform/bootstrap/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -123,7 +134,7 @@ module "dcos-bootstrap-instance" {
 
 module "dcos-master-instances" {
   source  = "dcos-terraform/masters/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -149,7 +160,7 @@ module "dcos-master-instances" {
 
 module "dcos-privateagent-instances" {
   source  = "dcos-terraform/private-agents/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -177,7 +188,7 @@ module "dcos-privateagent-instances" {
 // DC/OS tested OSes provides sample AMIs and user-data
 module "dcos-publicagent-instances" {
   source  = "dcos-terraform/public-agents/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"
@@ -206,7 +217,7 @@ module "dcos-publicagent-instances" {
 // Load balancers is providing two load balancers. One for accessing the DC/OS masters and a secondone balancing over public agents.
 module "dcos-elb" {
   source  = "dcos-terraform/elb-dcos/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"

--- a/variables.tf
+++ b/variables.tf
@@ -203,3 +203,8 @@ variable "public_agents_additional_ports" {
   description = "List of additional ports allowed for public access on public agents (80 and 443 open by default)"
   default     = []
 }
+
+variable "aws_s3_bucket" {
+  description = "S3 Bucket for External Exhibitor"
+  default     = ""
+}


### PR DESCRIPTION
- Adding the aws_s3_bucket variable to the infrastructure module. This is to get passed not only to the IAM module but also to create the S3 bucket resource if the variable exists. This is currently ONLY for external exhibitor on s3.

- Update previous source versions from 0.1 to 0.1.0

- Update the README to reflect new variable aws_s3_bucket as well as updated the variable spreadsheet to reflect new description

- Will need to update the source for IAM Module to reflect TF registry instead of the feature branch 