### PR TITLE
add missing version operator fixes dcos-terraform/terraform-aws-dcos#37

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "dcos-vpc" {
 // Firewall. Create policies for instances and load balancers
 module "dcos-security-groups" {
   source  = "dcos-terraform/security-groups/aws"
-  version = "0.1.0"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"


### PR DESCRIPTION
dcos-terraform/terraform-aws-dcos#37

with #11 we introduced an old bug as the version operator is missing we're pinning to an old version of the security group module