### PR TITLE
Add public_agents_ips to this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents_os | [PRIVATE AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | private_agents_root_volume_size | [PRIVATE AGENTS] Root volume size in GB | string | `120` | no |
 | private_agents_root_volume_type | [PRIVATE AGENTS] Root volume type | string | `gp2` | no |
+| public_agents_access_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | string | `<list>` | no |
 | public_agents_associate_public_ip_address | [PUBLIC AGENTS] Associate a public ip address with there instances | string | `true` | no |
 | public_agents_aws_ami | [PUBLIC AGENTS] AMI to be used | string | `` | no |
 | public_agents_iam_instance_profile | [PUBLIC AGENTS] Instance profile to be used for these instances | string | `` | no |
 | public_agents_instance_type | [PUBLIC AGENTS] Instance type | string | `m4.xlarge` | no |
-| public_agents_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public_agents_os | [PUBLIC AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | public_agents_root_volume_size | [PUBLIC AGENTS] Root volume size | string | `120` | no |
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents_os | [PRIVATE AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | private_agents_root_volume_size | [PRIVATE AGENTS] Root volume size in GB | string | `120` | no |
 | private_agents_root_volume_type | [PRIVATE AGENTS] Root volume type | string | `gp2` | no |
-| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |
+| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | string | `<list>` | no |
 | public_agents_associate_public_ip_address | [PUBLIC AGENTS] Associate a public ip address with there instances | string | `true` | no |
 | public_agents_aws_ami | [PUBLIC AGENTS] AMI to be used | string | `` | no |
 | public_agents_iam_instance_profile | [PUBLIC AGENTS] Instance profile to be used for these instances | string | `` | no |
 | public_agents_instance_type | [PUBLIC AGENTS] Instance type | string | `m4.xlarge` | no |
+| public_agents_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public_agents_os | [PUBLIC AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | public_agents_root_volume_size | [PUBLIC AGENTS] Root volume size | string | `120` | no |
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |
@@ -113,7 +114,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents.prereq-id | Returns the ID of the prereq script for private agents (if user_data or ami are not used) |
 | private_agents.private_ips | Private Agent instances private IPs |
 | private_agents.public_ips | Private Agent public IPs |
-| public_agents.instances | Public Agent instances IDs |
+| public_agents.instances | Private Agent |
 | public_agents.os_user | Private Agent instances private OS default user |
 | public_agents.prereq-id | Returns the ID of the prereq script for public agents (if user_data or ami are not used) |
 | public_agents.private_ips | Public Agent instances private IPs |

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ module "dcos-security-groups" {
   subnet_range                   = "${var.subnet_range}"
   cluster_name                   = "${var.cluster_name}"
   admin_ips                      = ["${var.admin_ips}"]
+  public_agents_ips              = ["${var.public_agents_ips}"]
   public_agents_additional_ports = ["${var.public_agents_additional_ports}"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ module "dcos-security-groups" {
   subnet_range                   = "${var.subnet_range}"
   cluster_name                   = "${var.cluster_name}"
   admin_ips                      = ["${var.admin_ips}"]
-  public_agents_ips              = ["${var.public_agents_ips}"]
+  public_agents_access_ips       = ["${var.public_agents_access_ips}"]
   public_agents_additional_ports = ["${var.public_agents_additional_ports}"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -209,7 +209,7 @@ variable "public_agents_additional_ports" {
   default     = []
 }
 
-variable "public_agents_ips" {
+variable "public_agents_access_ips" {
   description = "List of ips allowed access to public agents. admin_ips are joined to this list"
   type        = "list"
   default     = ["0.0.0.0/0"]

--- a/variables.tf
+++ b/variables.tf
@@ -209,6 +209,12 @@ variable "public_agents_additional_ports" {
   default     = []
 }
 
+variable "public_agents_ips" {
+  description = "List of ips allowed access to public agents. admin_ips are joined to this list"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "aws_s3_bucket" {
   description = "S3 Bucket for External Exhibitor"
   default     = ""


### PR DESCRIPTION
Users want to be able to add the ability to remove the default 0.0.0.0 on public agent security group and use specified IP range. This will address:

issue https://github.com/dcos-terraform/terraform-aws-dcos/issues/40 
JIRA Ticket: https://jira.mesosphere.com/browse/DCOS-47891 