### PR TITLE
vars: updating the aws_ami description

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents_os | [PRIVATE AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | private_agents_root_volume_size | [PRIVATE AGENTS] Root volume size in GB | string | `120` | no |
 | private_agents_root_volume_type | [PRIVATE AGENTS] Root volume type | string | `gp2` | no |
-| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |
+| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | string | `<list>` | no |
 | public_agents_associate_public_ip_address | [PUBLIC AGENTS] Associate a public ip address with there instances | string | `true` | no |
 | public_agents_aws_ami | [PUBLIC AGENTS] AMI to be used | string | `` | no |
 | public_agents_iam_instance_profile | [PUBLIC AGENTS] Instance profile to be used for these instances | string | `` | no |
@@ -113,7 +113,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents.prereq-id | Returns the ID of the prereq script for private agents (if user_data or ami are not used) |
 | private_agents.private_ips | Private Agent instances private IPs |
 | private_agents.public_ips | Private Agent public IPs |
-| public_agents.instances | Public Agent instances IDs |
+| public_agents.instances | Private Agent |
 | public_agents.os_user | Private Agent instances private OS default user |
 | public_agents.prereq-id | Returns the ID of the prereq script for public agents (if user_data or ami are not used) |
 | public_agents.private_ips | Public Agent instances private IPs |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
 | availability_zones | Availability zones to be used | list | `<list>` | no |
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | string | `` | no |
 | aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key_file to empty string | string | `` | no |
 | aws_s3_bucket | S3 Bucket for External Exhibitor | string | `` | no |
 | bootstrap_associate_public_ip_address | [BOOTSTRAP] Associate a public ip address with there instances | string | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "num_public_agents" {
 }
 
 variable "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   default     = ""
 }
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-47942

This commit is to be more descriptive on the aws_ami variable to allow users more visibility into what AMI's are required and how they are built.
The link to the mesosphere documentation is in the description of the variable.