### PR TITLE
var/readme: updating default CIDR block

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
 | ssh_public_key_file | Path to SSH public key. This is mandatory but can be set to an empty string if you want to use ssh_public_key with the key as string. | string | - | yes |
-| subnet_range | Private IP space to be used in CIDR format | string | `172.16.0.0/12` | no |
+| subnet_range | Private IP space to be used in CIDR format | string | `172.16.0.0/16` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents_os | [PRIVATE AGENTS] Operating system to use. Instead of using your own AMI you could use a provided OS. | string | `` | no |
 | private_agents_root_volume_size | [PRIVATE AGENTS] Root volume size in GB | string | `120` | no |
 | private_agents_root_volume_type | [PRIVATE AGENTS] Root volume type | string | `gp2` | no |
-| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |
+| public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | string | `<list>` | no |
 | public_agents_associate_public_ip_address | [PUBLIC AGENTS] Associate a public ip address with there instances | string | `true` | no |
 | public_agents_aws_ami | [PUBLIC AGENTS] AMI to be used | string | `` | no |
 | public_agents_iam_instance_profile | [PUBLIC AGENTS] Instance profile to be used for these instances | string | `` | no |
@@ -113,7 +113,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | private_agents.prereq-id | Returns the ID of the prereq script for private agents (if user_data or ami are not used) |
 | private_agents.private_ips | Private Agent instances private IPs |
 | private_agents.public_ips | Private Agent public IPs |
-| public_agents.instances | Public Agent instances IDs |
+| public_agents.instances | Private Agent |
 | public_agents.os_user | Private Agent instances private OS default user |
 | public_agents.prereq-id | Returns the ID of the prereq script for public agents (if user_data or ami are not used) |
 | public_agents.private_ips | Public Agent instances private IPs |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | public_agents_root_volume_type | [PUBLIC AGENTS] Specify the root volume type. | string | `gp2` | no |
 | ssh_public_key | SSH public key in authorized keys format (e.g. 'ssh-rsa ..') to be used with the instances. Make sure you added this key to your ssh-agent. | string | `` | no |
 | ssh_public_key_file | Path to SSH public key. This is mandatory but can be set to an empty string if you want to use ssh_public_key with the key as string. | string | - | yes |
-| subnet_range | Private IP space to be used in CIDR format | string | `172.12.0.0/16` | no |
+| subnet_range | Private IP space to be used in CIDR format | string | `172.16.0.0/12` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "availability_zones" {
 
 variable "subnet_range" {
   description = "Private IP space to be used in CIDR format"
-  default     = "172.16.0.0/12"
+  default     = "172.16.0.0/16"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "availability_zones" {
 
 variable "subnet_range" {
   description = "Private IP space to be used in CIDR format"
-  default     = "172.12.0.0/16"
+  default     = "172.16.0.0/12"
 }
 
 variable "tags" {


### PR DESCRIPTION
The universal installer currently is not using the correct private IP default CIDR as specified by RFC 1918.
https://tools.ietf.org/html/rfc1918

This PR is to correct this but will considered breaking change and must not be merged as a patch release but at least a minor/major version.