### PR TITLE
Additional outputs to satisfy adding additional agent modules with infrastructure module

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ Klick the stated link while being logged into the AWS Console ( Webinterface ) t
 | public_agents.prereq-id | Returns the ID of the prereq script for public agents (if user_data or ami are not used) |
 | public_agents.private_ips | Public Agent instances private IPs |
 | public_agents.public_ips | Public Agent public IPs |
+| security_group.admin | This is the id of the admin security_group that the cluster is in |
 | security_group.internal_id | This is the id of the internal security_group that the cluster is in |
 | vpc.cidr_block | This is the cidr_block of the VPC the cluster is in |
 | vpc.id | This is the id of the VPC the cluster is in |
 | vpc.main_route_table_id | This is the id of the VPC's main routing table the cluster is in |
+| vpc.subnet_ids | This is the list of subnet_ids the cluster is in |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -143,3 +143,8 @@ output "security_group.admin" {
   description = "This is the id of the admin security_group that the cluster is in"
   value       = "${module.dcos-security-groups.admin}"
 }
+
+output "aws_key_pair.key_name" {
+  description = "This is the key_name of the ssh key created"
+  value = "${aws_key_pair.deployer.*.key_name}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -124,7 +124,7 @@ output "lb.masters_internal_dns_name" {
   value       = "${module.dcos-lb.masters_internal_dns_name}"
 }
 
-output "security_groups.internal_id" {
+output "security_groups.internal" {
   description = "This is the id of the internal security_group that the cluster is in"
   value       = "${module.dcos-security-groups.internal}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "aws_key_pair.key_name" {
   description = "This is the key_name of the ssh key created"
-  value       = "${flatten(aws_key_pair.deployer.*.key_name)}"
+  value       = "${join(",", flatten(aws_key_pair.deployer.*.key_name))}"
 }
 
 output "bootstrap.instance" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "aws_key_pair.key_name" {
+  description = "This is the key_name of the ssh key created"
+  value       = "${aws_key_pair.deployer.*.key_name}"
+}
+
 output "bootstrap.instance" {
   description = "Bootstrap instance ID"
   value       = "${module.dcos-bootstrap-instance.instance}"
@@ -99,6 +104,11 @@ output "public_agents.prereq-id" {
   value       = "${module.dcos-publicagent-instances.prereq-id}"
 }
 
+output "iam.agent_profile" {
+  value       = "${module.dcos-iam.aws_agent_profile}"
+  description = "Name of the agent profile"
+}
+
 output "lb.public_agents_dns_name" {
   description = "This is the load balancer to reach the public agents"
   value       = "${module.dcos-lb.public_agents_dns_name}"
@@ -112,6 +122,16 @@ output "lb.masters_dns_name" {
 output "lb.masters_internal_dns_name" {
   description = "This is the load balancer to access the masters internally in the cluster"
   value       = "${module.dcos-lb.masters_internal_dns_name}"
+}
+
+output "security_group.internal_id" {
+  description = "This is the id of the internal security_group that the cluster is in"
+  value       = "${module.dcos-security-groups.internal}"
+}
+
+output "security_group.admin" {
+  description = "This is the id of the admin security_group that the cluster is in"
+  value       = "${module.dcos-security-groups.admin}"
 }
 
 output "vpc.id" {
@@ -132,19 +152,4 @@ output "vpc.main_route_table_id" {
 output "vpc.subnet_ids" {
   description = "This is the list of subnet_ids the cluster is in"
   value       = ["${module.dcos-vpc.subnet_ids}"]
-}
-
-output "security_group.internal_id" {
-  description = "This is the id of the internal security_group that the cluster is in"
-  value       = "${module.dcos-security-groups.internal}"
-}
-
-output "security_group.admin" {
-  description = "This is the id of the admin security_group that the cluster is in"
-  value       = "${module.dcos-security-groups.admin}"
-}
-
-output "aws_key_pair.key_name" {
-  description = "This is the key_name of the ssh key created"
-  value       = "${aws_key_pair.deployer.*.key_name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -124,12 +124,12 @@ output "lb.masters_internal_dns_name" {
   value       = "${module.dcos-lb.masters_internal_dns_name}"
 }
 
-output "security_group.internal_id" {
+output "security_groups.internal_id" {
   description = "This is the id of the internal security_group that the cluster is in"
   value       = "${module.dcos-security-groups.internal}"
 }
 
-output "security_group.admin" {
+output "security_groups.admin" {
   description = "This is the id of the admin security_group that the cluster is in"
   value       = "${module.dcos-security-groups.admin}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -129,7 +129,17 @@ output "vpc.main_route_table_id" {
   value       = "${module.dcos-vpc.aws_main_route_table_id}"
 }
 
+output "vpc.subnet_ids" {
+  description = "This is the list of subnet_ids the cluster is in"
+  value       = ["${module.dcos-vpc.subnet_ids}"]
+}
+
 output "security_group.internal_id" {
   description = "This is the id of the internal security_group that the cluster is in"
   value       = "${module.dcos-security-groups.internal}"
+}
+
+output "security_group.admin" {
+  description = "This is the id of the admin security_group that the cluster is in"
+  value       = "${module.dcos-security-groups.admin}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "aws_key_pair.key_name" {
   description = "This is the key_name of the ssh key created"
-  value       = "${aws_key_pair.deployer.*.key_name}"
+  value       = "${flatten(aws_key_pair.deployer.*.key_name)}"
 }
 
 output "bootstrap.instance" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -146,5 +146,5 @@ output "security_group.admin" {
 
 output "aws_key_pair.key_name" {
   description = "This is the key_name of the ssh key created"
-  value = "${aws_key_pair.deployer.*.key_name}"
+  value       = "${aws_key_pair.deployer.*.key_name}"
 }


### PR DESCRIPTION
When using the infrastructure module these outputs allow for additional private agent modules to use the resources created via infrastructure module:

- Admin SG
- subnet ids
- aws key
- IAM for agents